### PR TITLE
Fix file size calculation on MIPS

### DIFF
--- a/incbin.h
+++ b/incbin.h
@@ -97,6 +97,7 @@
 #  define INCBIN_SECTION         ".section .rodata\n"
 #  define INCBIN_GLOBAL(NAME)    ".global " #NAME "\n"
 #  define INCBIN_INT             ".int "
+#  define INCBIN_BYTE            ".byte "
 #if defined(__GNUC__)
 /*
  * GCC provides a predefined macro for assembler label prefixes that are expected
@@ -182,7 +183,7 @@
             INCBIN_TYPE(g ## NAME ## End) \
             INCBIN_ALIGN_BYTE \
             INCBIN_MANGLE "g" #NAME "End:\n" \
-                INCBIN_INT "1\n"\
+                INCBIN_BYTE "1\n"\
             INCBIN_GLOBAL(g ## NAME ## Size) \
             INCBIN_TYPE(g ## NAME ## Size) \
             INCBIN_ALIGN_HOST \


### PR DESCRIPTION
After crosscompiling [dnsdist](http://dnsdist.org) (which uses _incbin_) for MIPS, using GCC 4.8.3 (OpenWrt/Linaro GCC 4.8-2014.04 r46450 from OpenWRT 15.05 SDK), I noticed that the sizes of INCBIN'ed files are rounded up to the nearest multiple of 4.  It seems that the `.balign 1` specified for `g<NAME>End` is ignored and those symbols are aligned anyway due to the use of `.int`.  While my knowledge on this subject is too vague to determine whether it's a compiler bug or not, changing the `.int` to `.byte` seems to fix the issue on MIPS and, AFAICT, doesn't break any other architecture.
