### PR TITLE
One space kills the fun: Fix for OS X "unknown instruction .byte1"

### DIFF
--- a/incbin.h
+++ b/incbin.h
@@ -92,7 +92,7 @@
 #  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
 #  define INCBIN_INT             ".long "
 #  define INCBIN_MANGLE          "_"
-#  define INCBIN_BYTE            ".byte"
+#  define INCBIN_BYTE            ".byte "
 #  define INCBIN_TYPE(...)
 #else
 #  define INCBIN_SECTION         ".section .rodata\n"


### PR DESCRIPTION
As the title says, one space kills the fun.

Without the space, an instruction like `.byte1` might be generated, where 1 is the start byte. But it happens to basically any instruction generated from this.

One space, one fix. :)
