### PR TITLE
Add user configuration of linker output section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Include binary files in your C/C++ applications with ease
 
 ## Example
 
+``` c
     #include "incbin.h"
 
     INCBIN(Icon, "icon.png");
@@ -20,6 +21,7 @@ Include binary files in your C/C++ applications with ease
     // extern const unsigned char gIconData[];
     // extern const unsigned char gIconEnd; // a marker to the end, take the address to get the ending pointer
     // extern const unsigned int gIconSize;
+```
 
 ## Portability
 
@@ -67,6 +69,7 @@ By default, `incbin.h` emits symbols with a `g` prefix. This can be adjusted by
 defining `INCBIN_PREFIX` before including `incbin.h` with a desired prefix. For
 instance
 
+``` c
     #define INCBIN_PREFIX g_
     #include "incbin.h"
     INCBIN(test, "test.txt");
@@ -75,9 +78,11 @@ instance
     // const unsigned char g_testData[];
     // const unsigned char *g_testEnd;
     // const unsigned int g_testSize;
+```
 
-You can also choose to have no prefix by defining the prefix with nothing, e.g
+You can also choose to have no prefix by defining the prefix with nothing, for example:
 
+``` c
     #define INCBIN_PREFIX
     #include "incbin.h"
     INCBIN(test, "test.txt");
@@ -86,6 +91,7 @@ You can also choose to have no prefix by defining the prefix with nothing, e.g
     // const unsigned char testData[];
     // const unsigned char testEnd;
     // const unsigned int testSize;
+```
 
 ## Style
 By default, `incbin.h` emits symbols with `CamelCase` style. This can be adjusted
@@ -97,6 +103,7 @@ are two possible styles to choose from
 
 For instance:
 
+``` c
     #define INCBIN_STYLE INCBIN_STYLE_SNAKE
     #include "incbin.h"
     INCBIN(test, "test.txt");
@@ -105,9 +112,25 @@ For instance:
     // const unsigned char gtest_data[];
     // const unsigned char gtest_end;
     // const unsigned int gtest_size;
+```
 
 Combining both the style and prefix allows for you to adjust `incbin.h` to suite
 your existing style and practices.
+
+## Overriding Linker Output section
+By default, `incbin.h` emits into the read-only linker output section used on
+the detected platform. If you need to override this for whatever reason, you
+can manually specify the linker output section.
+
+For example, to emit data into program memory for
+[esp8266/Arduino](github.com/esp8266/Arduino):
+
+``` c
+#define INCBIN_OUTPUT_SECTION ".irom.text"
+#include "incbin.h"
+INCBIN(Foo, "foo.txt");
+// Data is emitted into program memory that never gets copied to RAM
+```
 
 ## Explanation
 

--- a/incbin.h
+++ b/incbin.h
@@ -98,16 +98,38 @@
 #  define INCBIN_CONST    const
 #endif
 
+/**
+ * @brief Optionally override the linker section into which data is emitted.
+ *
+ * @warning If you use this facility, you'll have to deal with platform-specific linker output
+ * section naming on your own
+ *
+ * Overriding the default linker output section, e.g for esp8266/Arduino:
+ * @code
+ * #define INCBIN_OUTPUT_SECTION ".irom.text"
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ * // Data is emitted into program memory that never gets copied to RAM
+ * @endcode
+ */
+#if !defined(INCBIN_OUTPUT_SECTION)
+#  if defined(__APPLE__)
+#    define INCBIN_OUTPUT_SECTION         ".const_data"
+#  else
+#    define INCBIN_OUTPUT_SECTION         ".rodata"
+#  endif
+#endif
+
 #if defined(__APPLE__)
 /* The directives are different for Apple branded compilers */
-#  define INCBIN_SECTION         ".const_data\n"
+#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
 #  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
 #  define INCBIN_INT             ".long "
 #  define INCBIN_MANGLE          "_"
 #  define INCBIN_BYTE            ".byte "
 #  define INCBIN_TYPE(...)
 #else
-#  define INCBIN_SECTION         ".section .rodata\n"
+#  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
 #  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
 #  define INCBIN_INT             ".int "
 #  if defined(__USER_LABEL_PREFIX__)


### PR DESCRIPTION
This was necessary work within the esp8266/Arduino project, as you can guess by my documented examples.

I also took the liberty of making the code blocks in the README actual code blocks.