### PR TITLE
Bunch of (I hope) improvements

### DIFF
--- a/incbin.h
+++ b/incbin.h
@@ -325,6 +325,16 @@
             INCBIN_STYLE_IDENT(SIZE))
 
 /**
+ * @brief If defined, one null-byte (value 0) is appended to the data
+ */
+#ifdef INCBIN_APPEND_TERMINATING_NULL
+#   define INCBIN_APPEND_AFTER_DATA \
+        INCBIN_BYTE "0\n"
+#else
+#   define INCBIN_APPEND_AFTER_DATA
+#endif
+
+/**
  * @brief Include a binary file into the current translation unit.
  *
  * Includes a binary file into the current translation unit, producing three symbols
@@ -364,6 +374,7 @@
             INCBIN_GLOBAL_LABELS(NAME, END) \
             INCBIN_ALIGN_BYTE \
             INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
+            INCBIN_APPEND_AFTER_DATA \
                 INCBIN_BYTE "1\n" \
             INCBIN_SIZE_SECTION \
             INCBIN_GLOBAL_LABELS(NAME, SIZE) \

--- a/incbin.h
+++ b/incbin.h
@@ -138,9 +138,19 @@
 #  endif
 #endif
 
+/**
+ * @brief Optionally override the linker section into which data size is emitted.
+ * Deaults to INCBIN_OUTPUT_SECTION
+ */
+#if !defined(INCBIN_SIZE_OUTPUT_SECTION)
+#   define INCBIN_SIZE_OUTPUT_SECTION     INCBIN_OUTPUT_SECTION
+#endif
+
+
 #if defined(__APPLE__)
 /* The directives are different for Apple branded compilers */
 #  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_SIZE_SECTION    INCBIN_SIZE_OUTPUT_SECTION "\n"
 #  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
 #  define INCBIN_INT             ".long "
 #  define INCBIN_MANGLE          "_"
@@ -148,6 +158,7 @@
 #  define INCBIN_TYPE(...)
 #else
 #  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_SIZE_SECTION    ".section " INCBIN_SIZE_OUTPUT_SECTION "\n"
 #  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
 #  if defined(__ghs__)
 #    define INCBIN_INT           ".word "
@@ -354,6 +365,7 @@
             INCBIN_ALIGN_BYTE \
             INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
                 INCBIN_BYTE "1\n" \
+            INCBIN_SIZE_SECTION \
             INCBIN_GLOBAL_LABELS(NAME, SIZE) \
             INCBIN_ALIGN_HOST \
             INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" \


### PR DESCRIPTION
Hi!

I've made an Adurino [library](https://github.com/arduino/library-registry) based on your project.

It required a few changes to be made to `incbin.h` which I think improve versatility and may be of use. All change are non-breaking and backward-compatible and I tried to follow the original code style closely.

## Explanation of every commit

### bbc30009 - Add an option to specify different sections for data and its size
Arduino is based on AVR MCU, which has true harvard architecture. Its program memory cannot be directly read from the program, it requires special instructions. Due to this limitation it is very inconvenient to store the size of the included binary data in ROM. The size variable should be stored in RAM, hence it should be in different section.
The commit adds an option to specify section for data size variable by defining `INCBIN_SIZE_OUTPUT_SECTION` macro. If undefined, it defaults to the value of `INCBIN_OUTPUT_SECTION`.


### 2e4c3222 - Add terminating NULL at the end of the data (optionallny)
When including text files, it is convenient to treat them as a c-string. The problem is that c-string should be NULL-terminated. This commit adds an option to add NULL byte at the end of the included data by defining `INCBIN_APPEND_TERMINATING_NULL`. Disabled by default.

Please check if I did ok there. I have a feeling this change may mess-up the alignment or something. I admit I don't fully understand the code here. For example, I don't understand why you append `.byte 1` at the end of the data.

### 566be487 - Add an option to specify typename for data
Adds an option to specify the resulting pointer type of the included data.
Just a convenience feature that removes the need of the cast every time you use the included data.
Adds two new macros `INCBIN_PTR_TYPE(NAME, FILENAME, DATA_PTR_TYPE)` and `INCBIN_EXTERN_PTR_TYPE(NAME, DATA_PTR_TYPE)` with one additional argument alongside the existing.
