### PR TITLE
use INCBIN_MANGLE in INCBIN_GLOBAL statement

### DIFF
--- a/incbin.h
+++ b/incbin.h
@@ -174,7 +174,7 @@
 #  define INCBIN_TYPE(...)
 #else
 #  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
-#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
 #  if defined(__ghs__)
 #    define INCBIN_INT           ".word "
 #  else


### PR DESCRIPTION
On 32-bit(x86) Windows, GCC apparently doesn't care, but Clang targeting i686-w64-windows-gnu does.  With this change, it works in both.