### PR TITLE
Remove outdated iOS bitcode warning

### DIFF
--- a/incbin.h
+++ b/incbin.h
@@ -161,10 +161,6 @@
 #endif
 
 #if defined(__APPLE__)
-#  include <TargetConditionals.h>
-#  if defined(TARGET_OS_IPHONE) && !defined(INCBIN_SILENCE_BITCODE_WARNING)
-#    warning "incbin is incompatible with bitcode. Using the library will break upload to App Store if you have bitcode enabled. Add `#define INCBIN_SILENCE_BITCODE_WARNING` before including this header to silence this warning."
-#  endif
 /* The directives are different for Apple branded compilers */
 #  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
 #  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"


### PR DESCRIPTION
This reverts b33ded1bf3d4766d20c14ae259777fde4dea50bc. Done since the [Xcode 14 Release Notes](https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-14-release-notes) from 2022 states that bitcode is now deprecated and App Store no longer accepts bitcode submissions from Xcode 14.

**DISCLAIMER**: I haven't actually tested uploading an iOS app using "incbin" to Apple app store myself. Someone should do so before the PR is merged.